### PR TITLE
Add FAISS persistence and Docker configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ venv/
 backend/venv/
 backend/__pycache__/
 backend/*.pyc
+backend/vector_index/
+backend/logs/
 *.pyd
 *.so
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -47,11 +47,21 @@ scripts/    # 自动化处理与管理工具
 ./init-db.sh       # 初始化数据库
 ```
 
+向量索引数据默认位于 `backend/vector_index`，容器会将该目录挂载到本地以保持数据持久化。
+
 启动后访问：
 
 - 🌐 前端：http://localhost:3000
 - 🛠️ 后端接口：http://localhost:8000
 - 📚 API 文档：http://localhost:8000/docs
+
+向量检索接口：
+
+```bash
+curl -X POST http://localhost:8000/api/v1/search/vector \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "咖啡馆 坐姿", "top_k": 5}'
+```
 
 ## 数据库初始化
 
@@ -64,6 +74,8 @@ scripts/    # 自动化处理与管理工具
 - `python backend/scripts/auto_process_images_enhanced.py --scan-oss`：扫描 OSS 并处理新图片。
 - `python backend/scripts/manage.py stats`：查看统计信息及热门搜索词。
 - `python backend/scripts/health_check.py --verbose`：输出依赖服务状态。
+- `python backend/scripts/build_vector_index.py`：生成姿势文本的向量索引。
+  结果存储在 `backend/vector_index/`，该目录通过 Docker 卷持久化。
 
 ## 贡献 & 开发
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -68,3 +68,9 @@ CORS_ORIGINS=*
 # ===========================================
 LOG_LEVEL=INFO
 LOG_FILE=logs/ai_analyzer.log
+
+# ===========================================
+# 向量索引配置
+# ===========================================
+VECTOR_INDEX_PATH=backend/vector_index/faiss.index
+VECTOR_ID_MAP_PATH=backend/vector_index/id_map.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,7 +36,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY . .
 
 # 创建必要目录
-RUN mkdir -p logs
+RUN mkdir -p logs backend/vector_index
 
 # 创建非root用户
 RUN useradd --create-home --shell /bin/bash app && \

--- a/backend/app/api/vector_search.py
+++ b/backend/app/api/vector_search.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+from typing import List, Tuple
+
+from ..services.vector_search_service import VectorSearchService
+
+router = APIRouter()
+
+# Dependency to create service instance
+
+def get_service():
+    return VectorSearchService()
+
+
+class VectorSearchRequest(BaseModel):
+    query: str
+    top_k: int = 10
+
+
+class VectorSearchResponse(BaseModel):
+    results: List[Tuple[int, float]]
+
+
+@router.post("/search/vector", response_model=VectorSearchResponse)
+async def vector_search(request: VectorSearchRequest, service: VectorSearchService = Depends(get_service)):
+    if not request.query.strip():
+        raise HTTPException(status_code=400, detail="Query cannot be empty")
+    try:
+        results = service.search(request.query, top_k=request.top_k)
+        return VectorSearchResponse(results=results)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ import logging
 from .database import get_db, engine
 from .api import ai_search
 from .api import ai_database_search  # 新增
+from .api import vector_search
 
 # 配置日志
 logging.basicConfig(level=logging.INFO)
@@ -33,6 +34,7 @@ app.add_middleware(
 # 注册外部路由模块
 app.include_router(ai_search.router, prefix="/api/v1", tags=["ai-search"])
 app.include_router(ai_database_search.router, prefix="/api/v1", tags=["ai-database-search"])  # 新增
+app.include_router(vector_search.router, prefix="/api/v1", tags=["vector-search"])
 # 改进的启动事件处理
 @app.on_event("startup")
 async def startup_event():

--- a/backend/app/services/vector_search_service.py
+++ b/backend/app/services/vector_search_service.py
@@ -1,0 +1,37 @@
+import json
+import os
+from typing import List, Tuple
+
+import numpy as np
+import openai
+import faiss
+
+EMBED_MODEL = os.getenv("OPENAI_MODEL", "text-embedding-3-small")
+INDEX_PATH = os.getenv("VECTOR_INDEX_PATH", "backend/vector_index/faiss.index")
+ID_MAP_PATH = os.getenv("VECTOR_ID_MAP_PATH", "backend/vector_index/id_map.json")
+
+
+class VectorSearchService:
+    def __init__(self, index_path: str = INDEX_PATH, id_map_path: str = ID_MAP_PATH):
+        if not os.path.exists(index_path) or not os.path.exists(id_map_path):
+            raise RuntimeError("Vector index not found. Run build_vector_index.py first")
+        self.index = faiss.read_index(index_path)
+        with open(id_map_path, "r", encoding="utf-8") as f:
+            self.id_map = json.load(f)
+
+    def _embed(self, text: str) -> np.ndarray:
+        resp = openai.embeddings.create(input=[text], model=EMBED_MODEL)
+        vec = np.array(resp.data[0].embedding, dtype="float32")
+        return vec
+
+    def search(self, query: str, top_k: int = 10) -> List[Tuple[int, float]]:
+        vec = self._embed(query)
+        D, I = self.index.search(vec.reshape(1, -1), top_k)
+        ids_scores = []
+        for idx, dist in zip(I[0], D[0]):
+            if idx < 0:
+                continue
+            pose_id = self.id_map[idx]
+            score = float(dist)
+            ids_scores.append((pose_id, score))
+        return ids_scores

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,3 +26,5 @@ python-dotenv==1.0.0
 jieba==0.42.1
 fuzzywuzzy==0.18.0
 python-Levenshtein==0.21.1
+faiss-cpu==1.7.4
+sentence-transformers==2.2.2

--- a/backend/scripts/build_vector_index.py
+++ b/backend/scripts/build_vector_index.py
@@ -1,0 +1,66 @@
+import json
+import os
+from typing import List
+
+import numpy as np
+import openai
+import faiss
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+
+# Embedding model name can be configured via OPENAI_MODEL env var
+EMBED_MODEL = os.getenv("OPENAI_MODEL", "text-embedding-3-small")
+INDEX_PATH = os.getenv("VECTOR_INDEX_PATH", "backend/vector_index/faiss.index")
+ID_MAP_PATH = os.getenv("VECTOR_ID_MAP_PATH", "backend/vector_index/id_map.json")
+
+
+def get_all_pose_text(db: Session) -> List[tuple[int, str]]:
+    sql = text(
+        """
+        SELECT p.id, p.title, p.description,
+               GROUP_CONCAT(t.name SEPARATOR ' ') as tags
+        FROM poses p
+        LEFT JOIN pose_tags pt ON p.id = pt.pose_id
+        LEFT JOIN tags t ON pt.tag_id = t.id
+        WHERE p.status = 'active'
+        GROUP BY p.id
+        """
+    )
+    rows = db.execute(sql).fetchall()
+    results = []
+    for row in rows:
+        combined = " ".join(filter(None, [row[1], row[2], row[3]]))
+        results.append((row[0], combined.strip()))
+    return results
+
+
+def embed_text(texts: List[str]) -> List[List[float]]:
+    resp = openai.embeddings.create(input=texts, model=EMBED_MODEL)
+    return [d.embedding for d in resp.data]
+
+
+def build_index():
+    db = SessionLocal()
+    try:
+        data = get_all_pose_text(db)
+        if not data:
+            print("No poses found")
+            return
+        ids, texts = zip(*data)
+        embeddings = embed_text(list(texts))
+        dim = len(embeddings[0])
+        index = faiss.IndexFlatL2(dim)
+        index.add(np.array(embeddings, dtype="float32"))
+        os.makedirs(os.path.dirname(INDEX_PATH), exist_ok=True)
+        faiss.write_index(index, INDEX_PATH)
+        with open(ID_MAP_PATH, "w", encoding="utf-8") as f:
+            json.dump(list(ids), f)
+        print(f"Index built with {len(ids)} entries")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    build_index()

--- a/docker-compose-external-bridge.yml
+++ b/docker-compose-external-bridge.yml
@@ -27,8 +27,11 @@ services:
       - OSS_BUCKET=${OSS_BUCKET}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4-vision-preview}
+      - VECTOR_INDEX_PATH=/app/backend/vector_index/faiss.index
+      - VECTOR_ID_MAP_PATH=/app/backend/vector_index/id_map.json
     volumes:
       - ./logs:/app/logs
+      - ./backend/vector_index:/app/backend/vector_index
     restart: unless-stopped
     extra_hosts:
       # 如果外部数据库在同一服务器上，添加主机映射

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -29,12 +29,15 @@ services:
       - OSS_BUCKET=${OSS_BUCKET}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4-vision-preview}
+      - VECTOR_INDEX_PATH=/app/backend/vector_index/faiss.index
+      - VECTOR_ID_MAP_PATH=/app/backend/vector_index/id_map.json
       
       # 绑定到所有接口以便前端访问
       - HOST=0.0.0.0
       - PORT=8000
     volumes:
       - ./logs:/app/logs
+      - ./backend/vector_index:/app/backend/vector_index
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,11 @@ services:
       - OSS_BUCKET=${OSS_BUCKET}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4-vision-preview}
+      - VECTOR_INDEX_PATH=/app/backend/vector_index/faiss.index
+      - VECTOR_ID_MAP_PATH=/app/backend/vector_index/id_map.json
     volumes:
       - ./backend/logs:/app/logs
+      - ./backend/vector_index:/app/backend/vector_index
     depends_on:
       - mysql
       - redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ flake8==6.1.0
 tabulate==0.9.0
 click==8.1.7
 python-dotenv==1.0.0
+faiss-cpu==1.7.4
+sentence-transformers==2.2.2


### PR DESCRIPTION
## Summary
- persist vector index in backend/vector_index
- mount vector index directory in Docker Compose setups
- create directory in backend Dockerfile
- document volume mapping and script output
- add vector index paths to example environment file

## Testing
- `python3 -m py_compile backend/scripts/build_vector_index.py backend/app/services/vector_search_service.py backend/app/api/vector_search.py backend/app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68590fb7596883328a98c7e15094a9a7