### PR TITLE
Add frontend vector search toggle

### DIFF
--- a/backend/app/api/vector_search.py
+++ b/backend/app/api/vector_search.py
@@ -102,3 +102,4 @@ async def vector_search(
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+

--- a/backend/app/api/vector_search.py
+++ b/backend/app/api/vector_search.py
@@ -1,12 +1,17 @@
 from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Any
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+import time
 
 from ..services.vector_search_service import VectorSearchService
+from ..database import get_db
 
 router = APIRouter()
 
 # Dependency to create service instance
+
 
 def get_service():
     return VectorSearchService()
@@ -17,16 +22,83 @@ class VectorSearchRequest(BaseModel):
     top_k: int = 10
 
 
+class PoseWithScore(BaseModel):
+    id: int
+    oss_url: str
+    thumbnail_url: str | None = None
+    title: str | None = None
+    description: str | None = None
+    scene_category: str | None = None
+    angle: str | None = None
+    shooting_tips: str | None = None
+    ai_tags: str | None = None
+    view_count: int | None = 0
+    created_at: str | None = None
+    score: float
+
+
 class VectorSearchResponse(BaseModel):
-    results: List[Tuple[int, float]]
+    poses: List[PoseWithScore]
+    total: int
+    query_time_ms: int
 
 
 @router.post("/search/vector", response_model=VectorSearchResponse)
-async def vector_search(request: VectorSearchRequest, service: VectorSearchService = Depends(get_service)):
+async def vector_search(
+    request: VectorSearchRequest,
+    db: Session = Depends(get_db),
+    service: VectorSearchService = Depends(get_service),
+):
     if not request.query.strip():
         raise HTTPException(status_code=400, detail="Query cannot be empty")
     try:
-        results = service.search(request.query, top_k=request.top_k)
-        return VectorSearchResponse(results=results)
+        start = time.time()
+        ids_scores = service.search(request.query, top_k=request.top_k)
+        pose_ids = [pid for pid, _ in ids_scores]
+
+        if not pose_ids:
+            return VectorSearchResponse(
+                poses=[], total=0, query_time_ms=int((time.time() - start) * 1000)
+            )
+
+        result = db.execute(
+            text(
+                """
+                SELECT id, oss_url, thumbnail_url, title, description,
+                       scene_category, angle, shooting_tips, ai_tags,
+                       view_count, created_at
+                FROM poses
+                WHERE id IN :ids
+                """
+            ),
+            {"ids": tuple(pose_ids)},
+        ).fetchall()
+
+        pose_dict: Dict[int, Dict[str, Any]] = {}
+        for row in result:
+            pose_dict[row[0]] = {
+                "id": row[0],
+                "oss_url": row[1],
+                "thumbnail_url": row[2],
+                "title": row[3] or "",
+                "description": row[4] or "",
+                "scene_category": row[5],
+                "angle": row[6],
+                "shooting_tips": row[7],
+                "ai_tags": row[8] or "",
+                "view_count": row[9] or 0,
+                "created_at": row[10].isoformat() if row[10] else None,
+            }
+
+        poses = []
+        for pid, score in ids_scores:
+            data = pose_dict.get(pid)
+            if data:
+                poses.append({**data, "score": score})
+
+        query_time = int((time.time() - start) * 1000)
+        return VectorSearchResponse(
+            poses=poses, total=len(poses), query_time_ms=query_time
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/app/api/search/vector/route.js
+++ b/frontend/app/api/search/vector/route.js
@@ -1,0 +1,16 @@
+import { proxyToBackendWithTimeout } from '@/lib/api-proxy'
+
+export async function POST(request) {
+  try {
+    return await proxyToBackendWithTimeout(request, `/api/v1/search/vector`)
+  } catch (error) {
+    console.error('Vector search request failed:', error)
+    return Response.json(
+      {
+        error: 'Vector search failed',
+        message: '向量搜索暂时不可用，请使用普通搜索'
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/search/vector/route.js
+++ b/frontend/app/api/search/vector/route.js
@@ -14,3 +14,4 @@ export async function POST(request) {
     )
   }
 }
+

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -97,7 +97,7 @@ function PosesPageContent() {
   useEffect(() => {
     console.log('Filters changed:', filters);
     fetchPoses(true);
-  }, [filters]); // 只依赖filters
+  }, [filters, fetchPoses]);
 
   // 无限滚动
   useEffect(() => {

--- a/frontend/components/EnhancedSearchBar.tsx
+++ b/frontend/components/EnhancedSearchBar.tsx
@@ -33,9 +33,6 @@ interface AIPoseResult {
   shooting_tips?: string;
 }
 
-interface VectorPoseResult extends AIPoseResult {
-  score: number
-}
 
 interface Props {
   onSearch: (query: string) => void;

--- a/frontend/components/EnhancedSearchBar.tsx
+++ b/frontend/components/EnhancedSearchBar.tsx
@@ -33,6 +33,10 @@ interface AIPoseResult {
   shooting_tips?: string;
 }
 
+interface VectorPoseResult extends AIPoseResult {
+  score: number
+}
+
 interface Props {
   onSearch: (query: string) => void;
   onAISearchResult?: (poses: AIPoseResult[]) => void;
@@ -55,6 +59,8 @@ const EnhancedSearchBar: React.FC<Props> = ({
   const [searchInfo, setSearchInfo] = useState<SearchInfo | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isAiDatabaseLoading, setIsAiDatabaseLoading] = useState(false);
+  const [isVectorLoading, setIsVectorLoading] = useState(false);
+  const [useVectorSearch, setUseVectorSearch] = useState(false);
   
   const inputRef = useRef<HTMLInputElement>(null);
   const suggestionsRef = useRef<HTMLDivElement>(null);
@@ -177,6 +183,65 @@ const EnhancedSearchBar: React.FC<Props> = ({
     }
   };
 
+  const handleVectorSearch = async () => {
+    if (!query.trim()) {
+      if (onResetSearch) {
+        onResetSearch();
+      }
+      return;
+    }
+
+    setIsVectorLoading(true);
+    setShowSuggestions(false);
+
+    try {
+      console.log('开始向量搜索:', query);
+      const response = await fetch('/api/search/vector', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: query.trim(),
+          top_k: 20,
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        console.log('向量搜索响应:', data);
+
+        setSearchInfo({
+          original_query: query,
+          ai_explanation: '使用向量相似度匹配',
+          search_intent: '向量匹配',
+          query_time: data.query_time_ms,
+          expanded_queries: [],
+          suggestions: [],
+        });
+
+        if (data.poses && Array.isArray(data.poses) && data.poses.length > 0) {
+          if (onAISearchResult) {
+            onAISearchResult(data.poses);
+          } else {
+            onSearch(query);
+          }
+        } else {
+          onSearch(query);
+        }
+      } else {
+        const errorText = await response.text();
+        console.error('向量搜索API响应错误:', response.status, errorText);
+        onSearch(query);
+      }
+    } catch (error) {
+      console.error('向量搜索失败:', error);
+      onSearch(query);
+    } finally {
+      setIsVectorLoading(false);
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (!showSuggestions || suggestions.length === 0) return;
 
@@ -270,15 +335,21 @@ return (
           disabled={isLoading || isAiDatabaseLoading}
         />
         
-        {/* AI数据库搜索按钮 */}
+        {/* AI数据库/向量 搜索按钮 */}
         <button
           type="button"
-          onClick={handleAiDatabaseSearch}
-          disabled={isLoading || isAiDatabaseLoading}
+          onClick={() => {
+            if (useVectorSearch) {
+              handleVectorSearch();
+            } else {
+              handleAiDatabaseSearch();
+            }
+          }}
+          disabled={isLoading || isAiDatabaseLoading || isVectorLoading}
           className="absolute right-12 top-1/2 -translate-y-1/2 p-2 text-gray-500 hover:text-purple-600 disabled:opacity-50 transition-colors flex items-center justify-center w-8 h-8"
           title="AI智能搜索"
         >
-          {isAiDatabaseLoading ? (
+          {isAiDatabaseLoading || isVectorLoading ? (
             <div className="w-5 h-5 border-2 border-purple-600 border-t-transparent rounded-full animate-spin"></div>
           ) : (
             <span className="text-lg">✨</span>
@@ -288,7 +359,7 @@ return (
         {/* 普通搜索按钮 */}
         <button
           type="submit"
-          disabled={isLoading || isAiDatabaseLoading}
+          disabled={isLoading || isAiDatabaseLoading || isVectorLoading}
           className="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-gray-500 hover:text-blue-600 disabled:opacity-50 transition-colors flex items-center justify-center w-8 h-8"
           title="普通搜索"
         >
@@ -300,6 +371,16 @@ return (
             </svg>
           )}
         </button>
+      </div>
+      <div className="flex items-center mt-2 text-sm">
+        <input
+          id="vector-toggle"
+          type="checkbox"
+          className="mr-2"
+          checked={useVectorSearch}
+          onChange={(e) => setUseVectorSearch(e.target.checked)}
+        />
+        <label htmlFor="vector-toggle">使用向量搜索</label>
       </div>
     </form>
 


### PR DESCRIPTION
## Summary
- support vector search results from backend
- proxy route for vector search
- toggle to enable vector search in `EnhancedSearchBar`

## Testing
- `npm run lint` *(fails: next not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859f7196030833294da5c17d56c94f3